### PR TITLE
Enable Astro i18n routing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,9 +4,20 @@ import sitemap from "@astrojs/sitemap";
 import tailwind from "@astrojs/tailwind";
 import { fileURLToPath } from "node:url";
 
+const SUPPORTED_LOCALES = ["en", "ko"];
+const DEFAULT_LOCALE = "en";
+
 export default defineConfig({
   site: "https://example.com",
   trailingSlash: "never",
+  i18n: {
+    defaultLocale: DEFAULT_LOCALE,
+    locales: SUPPORTED_LOCALES,
+    routing: {
+      prefixDefaultLocale: true,
+      redirectToDefaultLocale: false,
+    },
+  },
   integrations: [
     mdx({
       gfm: true,

--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -2,6 +2,7 @@
 import { formatPublishedDate } from "@/lib/datetime";
 import { getLocaleLabel, type Locale } from "@/config/locales";
 import type { NormalizedBlogEntry } from "@/lib/content/posts";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 interface Props {
   post: NormalizedBlogEntry;
@@ -36,7 +37,7 @@ const tags = entry.data.tags ?? [];
       <ul class="flex flex-wrap gap-2 text-xs">
         {tags.map((tag: string) => (
           <li class="rounded-full border border-border-light px-2 py-1 text-slate-500 transition hover:border-accent/60 hover:text-accent dark:border-border-dark dark:text-slate-400">
-            <a href={`/${post.locale}/tags/${tag}`}>#{tag}</a>
+            <a href={getRelativeLocaleUrl(post.locale, `tags/${tag}`)}>#{tag}</a>
           </li>
         ))}
       </ul>

--- a/src/config/locales.ts
+++ b/src/config/locales.ts
@@ -1,17 +1,17 @@
-export const SUPPORTED_LOCALES = ["ko", "en"] as const;
+export const SUPPORTED_LOCALES = ["en", "ko"] as const;
 
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 
-export const DEFAULT_LOCALE: Locale = "ko";
+export const DEFAULT_LOCALE: Locale = "en";
 
 export const LOCALE_LABELS: Record<Locale, string> = {
-  ko: "한국어",
   en: "English",
+  ko: "한국어",
 };
 
 export const LOCALE_FALLBACK_MESSAGES: Record<Locale, string> = {
-  ko: "번역이 준비 중입니다.",
   en: "Translation coming soon.",
+  ko: "번역이 준비 중입니다.",
 };
 
 export const DISPLAY_LOCALE_ORDER: Locale[] = [...SUPPORTED_LOCALES];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,7 +39,7 @@ const effectiveLocaleLinks = hasProvidedLocales ? computedLocaleLinks : fallback
 const canonical = new URL(Astro.url.pathname, Astro.site ?? "https://example.com").toString();
 
 const navLinks = [
-  { label: "Home", href: getRelativeLocaleUrl(locale) },
+  { label: "Home", href: getRelativeLocaleUrl(locale, "/") },
   { label: "Posts", href: getRelativeLocaleUrl(locale, "posts") },
   { label: "Tags", href: getRelativeLocaleUrl(locale, "tags") },
 ];
@@ -67,7 +67,7 @@ const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.ur
       >
         <a
           class="text-lg font-semibold tracking-tight text-text-light dark:text-text-dark"
-          href={getRelativeLocaleUrl(locale)}
+          href={getRelativeLocaleUrl(locale, "/")}
         >
           omin.blog
         </a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -38,10 +38,15 @@ const effectiveLocaleLinks = hasProvidedLocales ? computedLocaleLinks : fallback
 
 const canonical = new URL(Astro.url.pathname, Astro.site ?? "https://example.com").toString();
 
+const resolveLocaleHref = (path = "") => {
+  const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
+  return getRelativeLocaleUrl(locale, normalizedPath);
+};
+
 const navLinks = [
-  { label: "Home", href: getRelativeLocaleUrl(locale, "/") },
-  { label: "Posts", href: getRelativeLocaleUrl(locale, "posts") },
-  { label: "Tags", href: getRelativeLocaleUrl(locale, "tags") },
+  { label: "Home", href: resolveLocaleHref() },
+  { label: "Posts", href: resolveLocaleHref("posts") },
+  { label: "Tags", href: resolveLocaleHref("tags") },
 ];
 
 const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.url).pathname;
@@ -67,7 +72,7 @@ const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.ur
       >
         <a
           class="text-lg font-semibold tracking-tight text-text-light dark:text-text-dark"
-          href={getRelativeLocaleUrl(locale, "/")}
+          href={resolveLocaleHref()}
         >
           omin.blog
         </a>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,6 +39,10 @@ const effectiveLocaleLinks = hasProvidedLocales ? computedLocaleLinks : fallback
 const canonical = new URL(Astro.url.pathname, Astro.site ?? "https://example.com").toString();
 
 const resolveLocaleHref = (path = "") => {
+  if (!path) {
+    return getRelativeLocaleUrl(locale);
+  }
+
   const normalizedPath = path.startsWith("/") ? path.slice(1) : path;
   return getRelativeLocaleUrl(locale, normalizedPath);
 };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import ThemeToggle from "@/components/ThemeToggle.astro";
 import LocaleSwitcher from "@/components/LocaleSwitcher.astro";
 import ThemeScript from "@/components/ThemeScript.astro";
 import { DEFAULT_LOCALE, DISPLAY_LOCALE_ORDER, type Locale } from "@/config/locales";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 interface Props {
   title?: string;
@@ -21,7 +22,7 @@ const {
 } = Astro.props as Props;
 
 const fallbackLocaleLinks = Object.fromEntries(
-  DISPLAY_LOCALE_ORDER.map((candidate) => [candidate, `/${candidate}`] as const)
+  DISPLAY_LOCALE_ORDER.map((candidate) => [candidate, getRelativeLocaleUrl(candidate)] as const)
 ) as Record<Locale, string>;
 
 const computedLocaleLinks = DISPLAY_LOCALE_ORDER.reduce<Record<Locale, string | undefined>>(
@@ -38,9 +39,9 @@ const effectiveLocaleLinks = hasProvidedLocales ? computedLocaleLinks : fallback
 const canonical = new URL(Astro.url.pathname, Astro.site ?? "https://example.com").toString();
 
 const navLinks = [
-  { label: "Home", href: `/${locale}` },
-  { label: "Posts", href: `/${locale}/posts` },
-  { label: "Tags", href: `/${locale}/tags` },
+  { label: "Home", href: getRelativeLocaleUrl(locale) },
+  { label: "Posts", href: getRelativeLocaleUrl(locale, "posts") },
+  { label: "Tags", href: getRelativeLocaleUrl(locale, "tags") },
 ];
 
 const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.url).pathname;
@@ -66,7 +67,7 @@ const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.ur
       >
         <a
           class="text-lg font-semibold tracking-tight text-text-light dark:text-text-dark"
-          href={`/${locale}`}
+          href={getRelativeLocaleUrl(locale)}
         >
           omin.blog
         </a>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,53 @@
+import { defineMiddleware } from "astro:middleware";
+import { getRelativeLocaleUrl } from "astro:i18n";
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "./config/locales";
+
+function resolveLocaleFromHeader(header: string | null): Locale | undefined {
+  if (!header) {
+    return undefined;
+  }
+
+  const candidates = header
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  for (const candidate of candidates) {
+    const [language] = candidate.split(";");
+    if (!language) continue;
+
+    const normalized = language.toLowerCase();
+    const exact = SUPPORTED_LOCALES.find((locale) => locale === normalized);
+    if (exact) {
+      return exact;
+    }
+
+    const [root] = normalized.split("-");
+    const baseMatch = SUPPORTED_LOCALES.find((locale) => locale === root);
+    if (baseMatch) {
+      return baseMatch;
+    }
+  }
+
+  return undefined;
+}
+
+export const onRequest = defineMiddleware((context, next) => {
+  const { url, request } = context;
+  if (request.method.toUpperCase() !== "GET") {
+    return next();
+  }
+
+  const pathname = url.pathname;
+  const [firstSegment] = pathname.replace(/^\/+/, "").split("/");
+
+  if (!firstSegment) {
+    const preferred = resolveLocaleFromHeader(request.headers.get("accept-language"));
+    const locale = preferred ?? DEFAULT_LOCALE;
+    const destination = getRelativeLocaleUrl(locale);
+    const target = `${destination}${url.search}`;
+    return context.redirect(target);
+  }
+
+  return next();
+});

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -9,6 +9,7 @@ import {
   type Locale,
 } from "@/config/locales";
 import { getPostsForLocale } from "@/lib/content/posts";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
 
@@ -26,7 +27,7 @@ const posts = await getPostsForLocale(locale);
 const intro = getIntroForLocale(locale);
 const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>(
   (acc, candidate) => {
-    acc[candidate] = `/${candidate}`;
+    acc[candidate] = getRelativeLocaleUrl(candidate);
     return acc;
   },
   {} as Record<Locale, string | undefined>
@@ -76,7 +77,10 @@ const hasPosts = posts.length > 0;
             }
           </p>
         </div>
-        <a class="text-sm font-medium text-accent hover:underline" href={`/${locale}/posts`}>
+        <a
+          class="text-sm font-medium text-accent hover:underline"
+          href={getRelativeLocaleUrl(locale, "posts")}
+        >
           {locale === "ko" ? "전체 보기" : "View all"}
         </a>
       </header>

--- a/src/pages/[lang]/posts/[slug].astro
+++ b/src/pages/[lang]/posts/[slug].astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import PostMeta from "@/components/PostMeta.astro";
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { buildSlugIndex, getPostByLocaleSlug } from "@/lib/content/posts";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
 
@@ -39,7 +40,10 @@ const post = await getPostByLocaleSlug(locale, slugParam);
 
 if (!post) {
   return Astro.redirect(
-    `/${(Object.keys(entrySet) as Locale[])[0] ?? DEFAULT_LOCALE}/posts/${slugParam}`
+    getRelativeLocaleUrl(
+      (Object.keys(entrySet) as Locale[])[0] ?? DEFAULT_LOCALE,
+      `posts/${slugParam}`
+    )
   );
 }
 
@@ -47,7 +51,7 @@ const { Content } = await post.entry.render();
 const availableLocales = Object.keys(entrySet) as Locale[];
 const localeLinks = availableLocales.reduce<Record<Locale, string | undefined>>(
   (acc, candidate) => {
-    acc[candidate] = `/${candidate}/posts/${slugParam}`;
+    acc[candidate] = getRelativeLocaleUrl(candidate, `posts/${slugParam}`);
     return acc;
   },
   {} as Record<Locale, string | undefined>

--- a/src/pages/[lang]/posts/index.astro
+++ b/src/pages/[lang]/posts/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import PostCard from "@/components/PostCard.astro";
 import { LOCALE_FALLBACK_MESSAGES, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { getPostsForLocale } from "@/lib/content/posts";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
 
@@ -18,7 +19,7 @@ const locale = SUPPORTED_LOCALES.includes(paramsLocale as Locale)
 const posts = await getPostsForLocale(locale);
 const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>(
   (acc, candidate) => {
-    acc[candidate] = `/${candidate}/posts`;
+    acc[candidate] = getRelativeLocaleUrl(candidate, "posts");
     return acc;
   },
   {} as Record<Locale, string | undefined>
@@ -55,7 +56,7 @@ const tags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
             {tags.map(([tag, count]) => (
               <a
                 class="rounded-full border border-border-light px-3 py-1 transition hover:border-accent/60 hover:text-accent dark:border-border-dark"
-                href={`/${locale}/tags/${tag}`}
+                href={getRelativeLocaleUrl(locale, `tags/${tag}`)}
               >
                 #{tag} · {count}
               </a>

--- a/src/pages/[lang]/tags/[tag].astro
+++ b/src/pages/[lang]/tags/[tag].astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import PostCard from "@/components/PostCard.astro";
 import { LOCALE_FALLBACK_MESSAGES, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { loadBlogEntries } from "@/lib/content/posts";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
 
@@ -44,7 +45,7 @@ const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>
     const hasTag = allPosts.some(
       (post) => post.locale === candidate && (post.entry.data.tags ?? []).includes(tagParam)
     );
-    acc[candidate] = hasTag ? `/${candidate}/tags/${tagParam}` : undefined;
+    acc[candidate] = hasTag ? getRelativeLocaleUrl(candidate, `tags/${tagParam}`) : undefined;
     return acc;
   },
   {} as Record<Locale, string | undefined>

--- a/src/pages/[lang]/tags/index.astro
+++ b/src/pages/[lang]/tags/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { LOCALE_FALLBACK_MESSAGES, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { getPostsForLocale } from "@/lib/content/posts";
+import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
 
@@ -24,7 +25,7 @@ const tagCounts = posts.reduce<Record<string, number>>((acc, post) => {
 const tags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
 const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>(
   (acc, candidate) => {
-    acc[candidate] = `/${candidate}/tags`;
+    acc[candidate] = getRelativeLocaleUrl(candidate, "tags");
     return acc;
   },
   {} as Record<Locale, string | undefined>
@@ -57,7 +58,7 @@ const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>
               <li>
                 <a
                   class="inline-flex items-center gap-2 rounded-full border border-border-light px-3 py-1 transition hover:border-accent/60 hover:text-accent dark:border-border-dark"
-                  href={`/${locale}/tags/${tag}`}
+                  href={getRelativeLocaleUrl(locale, `tags/${tag}`)}
                 >
                   <span>#{tag}</span>
                   <span class="text-xs text-slate-400 dark:text-slate-500">{count}</span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,3 +1,0 @@
----
-return Astro.redirect(`/en${new URL(Astro.request.url).search}`);
----

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,30 @@
+---
+import { DEFAULT_LOCALE } from "@/config/locales";
+
+const redirectHref = `/${DEFAULT_LOCALE}`;
+const pageTitle = "Redirecting…";
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{pageTitle}</title>
+    <meta http-equiv="refresh" content={`0; url=${redirectHref}`} />
+    <meta name="robots" content="noindex" />
+  </head>
+  <body>
+    <p>
+      Redirecting to
+      <a href={redirectHref}>{redirectHref}</a>
+      …
+    </p>
+    <script is:inline>
+      const redirectPath = {JSON.stringify(redirectHref)};
+      const target = new URL(redirectPath, window.location.origin);
+      if (window.location.search) {
+        target.search = window.location.search;
+      }
+      window.location.replace(target.toString());
+    </script>
+  </body>
+</html>

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,8 +1,0 @@
-import type { APIRoute } from "astro";
-import { DEFAULT_LOCALE } from "@/config/locales";
-import { getRelativeLocaleUrl } from "astro:i18n";
-
-export const GET: APIRoute = ({ request, redirect }) => {
-  const search = new URL(request.url).search;
-  return redirect(`${getRelativeLocaleUrl(DEFAULT_LOCALE)}${search}`);
-};

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from "astro";
+import { DEFAULT_LOCALE } from "@/config/locales";
+import { getRelativeLocaleUrl } from "astro:i18n";
+
+export const GET: APIRoute = ({ request, redirect }) => {
+  const search = new URL(request.url).search;
+  return redirect(`${getRelativeLocaleUrl(DEFAULT_LOCALE)}${search}`);
+};

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -32,6 +32,24 @@ test.describe("omin.blog E2E", () => {
     await expect(page.getByRole("heading", { level: 1 })).toContainText("#");
   });
 
+  test("top navigation respects the active locale", async ({ page }) => {
+    for (const locale of ["en", "ko"] as const) {
+      await page.goto(`/${locale}/posts`, { waitUntil: "networkidle" });
+
+      await page.getByRole("link", { name: "Home" }).click();
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(new RegExp(`/${locale}/?(?:$|[?#])`));
+
+      await page.getByRole("link", { name: "Posts" }).click();
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(new RegExp(`/${locale}/posts/?(?:$|[?#])`));
+
+      await page.getByRole("link", { name: "Tags" }).click();
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveURL(new RegExp(`/${locale}/tags/?(?:$|[?#])`));
+    }
+  });
+
   test("persists theme preference through the toggle", async ({ page }) => {
     await page.goto("/en", { waitUntil: "networkidle" });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: [
+      "tests/e2e/**",
+      "node_modules/**",
+      "dist/**",
+      ".next/**",
+      "out/**",
+      "cypress/**",
+      "build/**",
+      "**/.{idea,git,cache,output,temp}/**",
+    ],
+    passWithNoTests: true,
+  },
+});


### PR DESCRIPTION
## Summary
- configure Astro i18n routing with the English default locale and locale prefixing
- add middleware to detect the preferred locale and redirect the root request accordingly
- update shared layout, locale pages, and post metadata to use Astro's i18n URL helpers and replace the index redirect with an endpoint

## Testing
- pnpm check
- pnpm test:e2e
------
https://chatgpt.com/codex/tasks/task_e_68e7d8b5147c832cbf6ef52017287297