### PR TITLE
Add i18next-based translations for localized UI copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "date-fns": "^4.1.0",
     "fast-glob": "^3.3.3",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "i18next": "^25.5.3"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/plans/i18n-research.md
+++ b/plans/i18n-research.md
@@ -1,0 +1,35 @@
+# i18n implementation research
+
+## Context
+
+- The existing Astro site already uses the built-in routing helpers from `astro:i18n`, but page copy is still hardcoded per locale with ternaries.
+- Requirement: introduce a translation solution backed by locale JSON files so UI copy (e.g., “View all”, “Latest Posts”) is centrally managed.
+
+## Options evaluated
+
+### 1. Built-in `astro:i18n` helpers only
+
+- Docs cover routing, locale params, and URL helpers but do not ship a translation dictionary API.
+- Would require crafting a bespoke loader/util around static JSON without any pluralization or interpolation helpers.
+- Verdict: minimal functionality; still need to write our own translation manager.
+
+### 2. `astro-i18next` community integration
+
+- Provides Astro components on top of `i18next` ([README](https://github.com/yassinedoghri/astro-i18next)).
+- Project disclaimer highlights missing tests and evolving API, so adopting it could introduce maintenance risk.
+- Verdict: promising but not production-ready enough for this blog.
+
+### 3. Direct `i18next` usage with JSON resources
+
+- `i18next` is a mature, framework-agnostic i18n library with interpolation, nesting, and async initialization.
+- We can colocate translation JSON files under `src/locales/<locale>.json` and expose a small helper (`getTranslator`) that memoizes per-locale instances for server-rendered Astro components.
+- Astro’s build pipeline can import JSON modules directly, so no extra tooling is required.
+- Verdict: preferred solution—gives us full-featured translations while keeping integration lightweight.
+
+## Implementation plan
+
+1. Add `i18next` dependency and create locale JSON files for `en` and `ko`.
+2. Introduce `src/lib/i18n/translator.ts` exposing `getTranslator(locale)` returning a memoized `t` function with interpolation support.
+3. Refactor shared layout/components (`BaseLayout`, `PostMeta`, etc.) and locale-aware pages to call `getTranslator` and replace hardcoded strings with translation keys.
+4. Update Playwright E2E tests to assert against translated copy per locale.
+5. Run `pnpm test:e2e` to confirm translations and routing continue to work.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      i18next:
+        specifier: ^25.5.3
+        version: 25.5.3(typescript@5.9.3)
     devDependencies:
       '@astrojs/check':
         specifier: ^0.9.4
@@ -1727,6 +1730,14 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  i18next@25.5.3:
+    resolution: {integrity: sha512-joFqorDeQ6YpIXni944upwnuHBf5IoPMuqAchGVeQLdWC2JOjxgM9V8UGLhNIIH/Q8QleRxIi0BSRQehSrDLcg==}
+    peerDependencies:
+      typescript: ^5
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -5468,6 +5479,12 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
+
+  i18next@25.5.3(typescript@5.9.3):
+    dependencies:
+      '@babel/runtime': 7.28.4
+    optionalDependencies:
+      typescript: 5.9.3
 
   ignore@5.3.2: {}
 

--- a/src/components/PostMeta.astro
+++ b/src/components/PostMeta.astro
@@ -2,6 +2,7 @@
 import { formatPublishedDate } from "@/lib/datetime";
 import { getLocaleLabel, type Locale } from "@/config/locales";
 import type { NormalizedBlogEntry } from "@/lib/content/posts";
+import { getTranslator } from "@/lib/i18n/translator";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
 interface Props {
@@ -12,6 +13,7 @@ interface Props {
 const { post, availableLocales } = Astro.props;
 const { entry } = post;
 const tags = entry.data.tags ?? [];
+const t = await getTranslator(post.locale);
 ---
 
 <div
@@ -44,7 +46,7 @@ const tags = entry.data.tags ?? [];
     )
   }
   <div class="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-    <span class="font-semibold uppercase tracking-widest">Available:</span>
+    <span class="font-semibold uppercase tracking-widest">{t("postMeta.available")}</span>
     {
       availableLocales.map((locale) => (
         <span

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,5 +1,14 @@
 ---
+import { DEFAULT_LOCALE, type Locale } from "@/config/locales";
 import { THEME_OPTIONS } from "@/lib/theme";
+import { getTranslator } from "@/lib/i18n/translator";
+
+interface Props {
+  locale?: Locale;
+}
+
+const { locale = DEFAULT_LOCALE } = Astro.props as Props;
+const t = await getTranslator(locale);
 
 const options = THEME_OPTIONS;
 ---
@@ -12,7 +21,7 @@ const options = THEME_OPTIONS;
     type="button"
     data-theme-option="light"
     class="flex h-7 w-7 items-center justify-center rounded text-slate-400 transition-all hover:text-slate-600 dark:hover:text-slate-300"
-    aria-label="Light theme"
+    aria-label={t("themeToggle.light")}
     aria-pressed="false"
   >
     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -27,7 +36,7 @@ const options = THEME_OPTIONS;
     type="button"
     data-theme-option="dark"
     class="flex h-7 w-7 items-center justify-center rounded text-slate-400 transition-all hover:text-slate-600 dark:hover:text-slate-300"
-    aria-label="Dark theme"
+    aria-label={t("themeToggle.dark")}
     aria-pressed="false"
   >
     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -42,7 +51,7 @@ const options = THEME_OPTIONS;
     type="button"
     data-theme-option="system"
     class="flex h-7 w-7 items-center justify-center rounded text-slate-400 transition-all hover:text-slate-600 dark:hover:text-slate-300"
-    aria-label="System theme"
+    aria-label={t("themeToggle.system")}
     aria-pressed="false"
   >
     <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -5,6 +5,7 @@ import ThemeToggle from "@/components/ThemeToggle.astro";
 import LocaleSwitcher from "@/components/LocaleSwitcher.astro";
 import ThemeScript from "@/components/ThemeScript.astro";
 import { DEFAULT_LOCALE, DISPLAY_LOCALE_ORDER, type Locale } from "@/config/locales";
+import { getTranslator } from "@/lib/i18n/translator";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
 interface Props {
@@ -15,11 +16,17 @@ interface Props {
 }
 
 const {
-  title = "Astro Blog v2",
-  description = "Locale-aware blogging experience powered by Astro.",
-  locale = DEFAULT_LOCALE,
+  title: providedTitle,
+  description: providedDescription,
+  locale: providedLocale = DEFAULT_LOCALE,
   localeLinks = {} as Record<Locale, string | undefined>,
 } = Astro.props as Props;
+
+const locale = providedLocale ?? DEFAULT_LOCALE;
+const t = await getTranslator(locale);
+
+const title = providedTitle ?? t("layout.defaultTitle");
+const description = providedDescription ?? t("layout.defaultDescription");
 
 const fallbackLocaleLinks = Object.fromEntries(
   DISPLAY_LOCALE_ORDER.map((candidate) => [candidate, getRelativeLocaleUrl(candidate)] as const)
@@ -48,9 +55,9 @@ const resolveLocaleHref = (path = "") => {
 };
 
 const navLinks = [
-  { label: "Home", href: resolveLocaleHref() },
-  { label: "Posts", href: resolveLocaleHref("posts") },
-  { label: "Tags", href: resolveLocaleHref("tags") },
+  { label: t("layout.nav.home"), href: resolveLocaleHref() },
+  { label: t("layout.nav.posts"), href: resolveLocaleHref("posts") },
+  { label: t("layout.nav.tags"), href: resolveLocaleHref("tags") },
 ];
 
 const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.url).pathname;
@@ -110,10 +117,11 @@ const isActive = (href: string) => Astro.url.pathname === new URL(href, Astro.ur
       <div
         class="mx-auto flex max-w-5xl flex-col gap-3 px-4 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8"
       >
-        <p>© {new Date().getFullYear()} omin. Crafted with Astro.</p>
+        <p>{t("layout.footer.copyright", { year: new Date().getFullYear() })}</p>
         <div class="flex items-center gap-4">
-          <a class="hover:text-accent" href="https://docs.astro.build/">Read the Astro docs</a>
-          <ThemeToggle />
+          <a class="hover:text-accent" href="https://docs.astro.build/">{t("layout.footer.docs")}</a
+          >
+          <ThemeToggle locale={locale} />
         </div>
       </div>
     </footer>

--- a/src/lib/i18n/translator.ts
+++ b/src/lib/i18n/translator.ts
@@ -1,0 +1,46 @@
+import i18next, { type TFunction } from "i18next";
+
+import en from "@/locales/en.json";
+import ko from "@/locales/ko.json";
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
+
+type ResourceMap = Record<Locale, { translation: Record<string, unknown> }>;
+
+export const translationDictionaries = {
+  en,
+  ko,
+} as const satisfies Record<Locale, Record<string, unknown>>;
+
+const resources: ResourceMap = Object.fromEntries(
+  Object.entries(translationDictionaries).map(([locale, translation]) => [locale, { translation }])
+) as ResourceMap;
+
+const translatorCache = new Map<Locale, Promise<TFunction>>();
+
+function resolveLocale(locale: Locale | string | undefined): Locale {
+  if (locale && SUPPORTED_LOCALES.includes(locale as Locale)) {
+    return locale as Locale;
+  }
+  return DEFAULT_LOCALE;
+}
+
+export async function getTranslator(locale: Locale | string | undefined): Promise<TFunction> {
+  const targetLocale = resolveLocale(locale);
+  if (!translatorCache.has(targetLocale)) {
+    const instance = i18next.createInstance();
+    const translatorPromise = instance
+      .init({
+        lng: targetLocale,
+        fallbackLng: DEFAULT_LOCALE,
+        resources,
+        interpolation: { escapeValue: false },
+        initImmediate: false,
+      })
+      .then(() => instance.getFixedT(targetLocale));
+    translatorCache.set(targetLocale, translatorPromise);
+  }
+
+  return translatorCache.get(targetLocale)!;
+}
+
+export type TranslationKey = Parameters<TFunction>[0];

--- a/src/lib/i18n/translator.ts
+++ b/src/lib/i18n/translator.ts
@@ -11,9 +11,9 @@ export const translationDictionaries = {
   ko,
 } as const satisfies Record<Locale, Record<string, unknown>>;
 
-const resources: ResourceMap = Object.fromEntries(
+const resources = Object.fromEntries(
   Object.entries(translationDictionaries).map(([locale, translation]) => [locale, { translation }])
-) as ResourceMap;
+) as unknown as ResourceMap;
 
 const translatorCache = new Map<Locale, Promise<TFunction>>();
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,44 @@
+{
+  "layout": {
+    "defaultTitle": "Astro Blog v2",
+    "defaultDescription": "Locale-aware blogging experience powered by Astro.",
+    "nav": {
+      "home": "Home",
+      "posts": "Posts",
+      "tags": "Tags"
+    },
+    "footer": {
+      "copyright": "© {{year}} omin. Crafted with Astro.",
+      "docs": "Read the Astro docs"
+    }
+  },
+  "home": {
+    "greeting": "Hello",
+    "latest": {
+      "title": "Latest Posts",
+      "subtitle": "New stories land here as soon as they are added.",
+      "viewAll": "View all"
+    }
+  },
+  "posts": {
+    "heading": "All Posts",
+    "description": "Posts appear per locale. Use the language switcher above to change what you see."
+  },
+  "tags": {
+    "browse": "Browse tags",
+    "title": "Topics",
+    "description": "Choose a tag to filter posts that are available in this locale."
+  },
+  "tagDetail": {
+    "breadcrumb": "Tag",
+    "description": "Posts grouped by this tag."
+  },
+  "postMeta": {
+    "available": "Available:"
+  },
+  "themeToggle": {
+    "light": "Light theme",
+    "dark": "Dark theme",
+    "system": "System theme"
+  }
+}

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -1,0 +1,44 @@
+{
+  "layout": {
+    "defaultTitle": "Astro 블로그 v2",
+    "defaultDescription": "Astro로 구현한 다국어 블로그 경험입니다.",
+    "nav": {
+      "home": "홈",
+      "posts": "게시글",
+      "tags": "태그"
+    },
+    "footer": {
+      "copyright": "© {{year}} omin. Astro로 제작했습니다.",
+      "docs": "Astro 문서 읽기"
+    }
+  },
+  "home": {
+    "greeting": "안녕하세요",
+    "latest": {
+      "title": "최신 글",
+      "subtitle": "새로운 글은 자동으로 여기에 표시됩니다.",
+      "viewAll": "전체 보기"
+    }
+  },
+  "posts": {
+    "heading": "전체 게시글",
+    "description": "언어별로 게시글이 분리되어 있습니다. 필요한 언어를 상단에서 선택하세요."
+  },
+  "tags": {
+    "browse": "태그 살펴보기",
+    "title": "주제별 게시글",
+    "description": "태그를 선택하면 해당 언어에 번역된 글만 필터링됩니다."
+  },
+  "tagDetail": {
+    "breadcrumb": "태그",
+    "description": "이 태그로 분류된 게시글 목록입니다."
+  },
+  "postMeta": {
+    "available": "지원 언어:"
+  },
+  "themeToggle": {
+    "light": "라이트 테마",
+    "dark": "다크 테마",
+    "system": "시스템 설정 따르기"
+  }
+}

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -9,6 +9,7 @@ import {
   type Locale,
 } from "@/config/locales";
 import { getPostsForLocale } from "@/lib/content/posts";
+import { getTranslator } from "@/lib/i18n/translator";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
@@ -25,6 +26,7 @@ const locale = SUPPORTED_LOCALES.includes(paramsLocale as Locale)
 const posts = await getPostsForLocale(locale);
 
 const intro = getIntroForLocale(locale);
+const t = await getTranslator(locale);
 const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>(
   (acc, candidate) => {
     acc[candidate] = getRelativeLocaleUrl(candidate);
@@ -42,7 +44,7 @@ const hasPosts = posts.length > 0;
   >
     <div class="mx-auto flex max-w-4xl flex-col gap-6">
       <p class="text-sm uppercase tracking-widest text-accent-soft dark:text-accent">
-        {locale === "ko" ? "안녕하세요" : "Hello"}
+        {t("home.greeting")}
       </p>
       <h1
         class="text-4xl font-semibold tracking-tight text-text-light dark:text-text-dark sm:text-5xl"
@@ -67,21 +69,15 @@ const hasPosts = posts.length > 0;
       <header class="flex items-center justify-between">
         <div>
           <h2 class="text-2xl font-semibold tracking-tight text-text-light dark:text-text-dark">
-            {locale === "ko" ? "최신 글" : "Latest Posts"}
+            {t("home.latest.title")}
           </h2>
-          <p class="text-sm text-slate-500 dark:text-slate-400">
-            {
-              locale === "ko"
-                ? "새로운 글은 자동으로 여기에 표시됩니다."
-                : "New stories land here as soon as they are added."
-            }
-          </p>
+          <p class="text-sm text-slate-500 dark:text-slate-400">{t("home.latest.subtitle")}</p>
         </div>
         <a
           class="text-sm font-medium text-accent hover:underline"
           href={getRelativeLocaleUrl(locale, "posts")}
         >
-          {locale === "ko" ? "전체 보기" : "View all"}
+          {t("home.latest.viewAll")}
         </a>
       </header>
 

--- a/src/pages/[lang]/posts/index.astro
+++ b/src/pages/[lang]/posts/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import PostCard from "@/components/PostCard.astro";
 import { LOCALE_FALLBACK_MESSAGES, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { getPostsForLocale } from "@/lib/content/posts";
+import { getTranslator } from "@/lib/i18n/translator";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
@@ -32,22 +33,17 @@ const tagCounts = posts.reduce<Record<string, number>>((acc, post) => {
   return acc;
 }, {});
 const tags = Object.entries(tagCounts).sort((a, b) => b[1] - a[1]);
+const t = await getTranslator(locale);
 ---
 
-<BaseLayout title="Posts" locale={locale} localeLinks={localeLinks}>
+<BaseLayout title={t("posts.heading")} locale={locale} localeLinks={localeLinks}>
   <section class="px-4 py-12 sm:px-6 lg:px-8">
     <div class="mx-auto flex max-w-5xl flex-col gap-10">
       <header class="flex flex-col gap-3">
         <h1 class="text-3xl font-semibold tracking-tight text-text-light dark:text-text-dark">
-          {locale === "ko" ? "전체 게시글" : "All Posts"}
+          {t("posts.heading")}
         </h1>
-        <p class="text-sm text-slate-500 dark:text-slate-400">
-          {
-            locale === "ko"
-              ? "언어별로 게시글이 분리되어 있습니다. 필요한 언어를 상단에서 선택하세요."
-              : "Posts appear per locale. Use the language switcher above to change what you see."
-          }
-        </p>
+        <p class="text-sm text-slate-500 dark:text-slate-400">{t("posts.description")}</p>
       </header>
 
       {

--- a/src/pages/[lang]/tags/[tag].astro
+++ b/src/pages/[lang]/tags/[tag].astro
@@ -3,6 +3,7 @@ import BaseLayout from "@/layouts/BaseLayout.astro";
 import PostCard from "@/components/PostCard.astro";
 import { LOCALE_FALLBACK_MESSAGES, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { loadBlogEntries } from "@/lib/content/posts";
+import { getTranslator } from "@/lib/i18n/translator";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
@@ -52,6 +53,7 @@ const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>
 );
 
 const tagHeading = `#${tagParam}`;
+const t = await getTranslator(locale);
 ---
 
 <BaseLayout title={tagHeading} locale={locale} localeLinks={localeLinks}>
@@ -59,14 +61,12 @@ const tagHeading = `#${tagParam}`;
     <div class="mx-auto flex max-w-5xl flex-col gap-8">
       <header class="space-y-2">
         <p class="text-sm uppercase tracking-widest text-accent-soft dark:text-accent">
-          {locale === "ko" ? "태그" : "Tag"}
+          {t("tagDetail.breadcrumb")}
         </p>
         <h1 class="text-3xl font-semibold tracking-tight text-text-light dark:text-text-dark">
           {tagHeading}
         </h1>
-        <p class="text-sm text-slate-500 dark:text-slate-400">
-          {locale === "ko" ? "이 태그로 분류된 게시글 목록입니다." : "Posts grouped by this tag."}
-        </p>
+        <p class="text-sm text-slate-500 dark:text-slate-400">{t("tagDetail.description")}</p>
       </header>
 
       {

--- a/src/pages/[lang]/tags/index.astro
+++ b/src/pages/[lang]/tags/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from "@/layouts/BaseLayout.astro";
 import { LOCALE_FALLBACK_MESSAGES, SUPPORTED_LOCALES, type Locale } from "@/config/locales";
 import { getPostsForLocale } from "@/lib/content/posts";
+import { getTranslator } from "@/lib/i18n/translator";
 import { getRelativeLocaleUrl } from "astro:i18n";
 
 export const prerender = true;
@@ -30,25 +31,20 @@ const localeLinks = SUPPORTED_LOCALES.reduce<Record<Locale, string | undefined>>
   },
   {} as Record<Locale, string | undefined>
 );
+const t = await getTranslator(locale);
 ---
 
-<BaseLayout title="Tags" locale={locale} localeLinks={localeLinks}>
+<BaseLayout title={t("tags.title")} locale={locale} localeLinks={localeLinks}>
   <section class="px-4 py-12 sm:px-6 lg:px-8">
     <div class="mx-auto flex max-w-4xl flex-col gap-8">
       <header class="space-y-3">
         <p class="text-sm uppercase tracking-widest text-accent-soft dark:text-accent">
-          {locale === "ko" ? "태그 살펴보기" : "Browse tags"}
+          {t("tags.browse")}
         </p>
         <h1 class="text-3xl font-semibold tracking-tight text-text-light dark:text-text-dark">
-          {locale === "ko" ? "주제별 게시글" : "Topics"}
+          {t("tags.title")}
         </h1>
-        <p class="text-sm text-slate-500 dark:text-slate-400">
-          {
-            locale === "ko"
-              ? "태그를 선택하면 해당 언어에 번역된 글만 필터링됩니다."
-              : "Choose a tag to filter posts that are available in this locale."
-          }
-        </p>
+        <p class="text-sm text-slate-500 dark:text-slate-400">{t("tags.description")}</p>
       </header>
 
       {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -4,7 +4,8 @@ import { DEFAULT_LOCALE } from "@/config/locales";
 const redirectHref = `/${DEFAULT_LOCALE}`;
 const pageTitle = "Redirecting…";
 ---
-<!DOCTYPE html>
+
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -18,9 +19,8 @@ const pageTitle = "Redirecting…";
       <a href={redirectHref}>{redirectHref}</a>
       …
     </p>
-    <script is:inline>
-      const redirectPath = {JSON.stringify(redirectHref)};
-      const target = new URL(redirectPath, window.location.origin);
+    <script is:inline define:vars={{ redirectHref }}>
+      const target = new URL(redirectHref, window.location.origin);
       if (window.location.search) {
         target.search = window.location.search;
       }

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -1,11 +1,23 @@
 import { test, expect } from "@playwright/test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const enTranslations = require("../../src/locales/en.json");
+const koTranslations = require("../../src/locales/ko.json");
+
+const translations = {
+  en: enTranslations,
+  ko: koTranslations,
+} as const;
 
 test.describe("omin.blog E2E", () => {
   test("redirects root to default locale home", async ({ page }) => {
     await page.goto("/", { waitUntil: "networkidle" });
 
     await expect(page).toHaveURL(/\/en$/);
-    await expect(page.getByRole("heading", { name: /Latest Posts/i })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: translations.en.home.latest.title })
+    ).toBeVisible();
     await expect(page.locator("article").first()).toBeVisible();
   });
 
@@ -16,7 +28,7 @@ test.describe("omin.blog E2E", () => {
     await page.waitForLoadState("networkidle");
 
     await expect(page).toHaveURL(/\/ko\/posts$/);
-    await expect(page.getByRole("heading", { name: "전체 게시글" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: translations.ko.posts.heading })).toBeVisible();
   });
 
   test("navigates to tag detail pages", async ({ page }) => {
@@ -36,15 +48,15 @@ test.describe("omin.blog E2E", () => {
     for (const locale of ["en", "ko"] as const) {
       await page.goto(`/${locale}/posts`, { waitUntil: "networkidle" });
 
-      await page.getByRole("link", { name: "Home" }).click();
+      await page.getByRole("link", { name: translations[locale].layout.nav.home }).click();
       await page.waitForLoadState("networkidle");
       await expect(page).toHaveURL(new RegExp(`/${locale}/?(?:$|[?#])`));
 
-      await page.getByRole("link", { name: "Posts" }).click();
+      await page.getByRole("link", { name: translations[locale].layout.nav.posts }).click();
       await page.waitForLoadState("networkidle");
       await expect(page).toHaveURL(new RegExp(`/${locale}/posts/?(?:$|[?#])`));
 
-      await page.getByRole("link", { name: "Tags" }).click();
+      await page.getByRole("link", { name: translations[locale].layout.nav.tags }).click();
       await page.waitForLoadState("networkidle");
       await expect(page).toHaveURL(new RegExp(`/${locale}/tags/?(?:$|[?#])`));
     }
@@ -53,7 +65,7 @@ test.describe("omin.blog E2E", () => {
   test("persists theme preference through the toggle", async ({ page }) => {
     await page.goto("/en", { waitUntil: "networkidle" });
 
-    const darkToggle = page.getByRole("button", { name: "Dark theme" });
+    const darkToggle = page.getByRole("button", { name: translations.en.themeToggle.dark });
     await darkToggle.click();
 
     await expect(darkToggle).toHaveAttribute("aria-pressed", "true");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,12 @@
     },
     "types": ["astro/client", "vitest/globals"]
   },
-  "include": ["src", "scripts", "astro.config.mjs", "tailwind.config.ts", "vitest.config.ts"]
+  "include": [
+    "src",
+    "scripts",
+    "tests",
+    "astro.config.mjs",
+    "tailwind.config.ts",
+    "vitest.config.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- add i18next with shared translation dictionaries under `src/locales`
- refactor layout, pages, and components to use `getTranslator` for localized UI text
- document i18n research findings and update Playwright tests to assert translated labels

## Testing
- pnpm test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68e8770283b0832cbe85d8eaf43c6b5b